### PR TITLE
使用“同义词”

### DIFF
--- a/zh-cn/docs/commands/Send.htm
+++ b/zh-cn/docs/commands/Send.htm
@@ -91,7 +91,7 @@ SendEvent Keys</pre>
 <p class="note"><strong>注意</strong>: 由于大写字母是通过发送 SHIFT 键产生的, 因此在某些程序中 <code>A</code> 和 <code>a</code> 会产生不同的效果. 例如, <code>!A</code> 按下 ALT+SHIFT+A 而 <code>!a</code> 按下 ALT+a. 如果不确定, 请使用小写字母.</p>
 <p><br>
 <strong id="SendInput">SendInput</strong> 和 <strong id="SendPlay">SendPlay</strong> <span class="ver">[v1.0.43+]</span>: SendInput 和 SendPlay 与 Send 使用相同的语法但通常更快更可靠. 此外, 它们缓存了发送期间任何物理的键盘或鼠标活动, 这样避免了在发送时夹杂用户的键击. 可以使用 <a href="SendMode.htm">SendMode</a> 让 Send 和 SendInput 或 SendPlay 执行相同的功能. 关于每种模式的更多细节, 请参阅下面的 <a href="#SendInputDetail">SendInput</a> 和 <a href="#SendPlayDetail">SendPlay</a>.</p>
-<p><a name="SendEvent"></a><strong>SendEvent</strong> <span class="ver">[v1.0.43+]</span>: SendEvent 和 1.0.43 之前版本的 <em>Send</em> 命令使用相同的方法发送键击. 键击发送的频率由 <a href="SetKeyDelay.htm">SetKeyDelay</a> 决定. 默认情况下, <em>Send</em> 和 <em>SendEvent</em> 功能相同; 但通过 <a href="SendMode.htm">SendMode</a> 可以让它变成和 <a href="#SendInputDetail">SendInput</a> 或 <a href="#SendPlayDetail">SendPlay</a> 一样.</p>
+<p><a name="SendEvent"></a><strong>SendEvent</strong> <span class="ver">[v1.0.43+]</span>: SendEvent 和 1.0.43 之前版本的 <em>Send</em> 命令使用相同的方法发送键击. 键击发送的频率由 <a href="SetKeyDelay.htm">SetKeyDelay</a> 决定. 默认情况下, <em>Send</em> 和 <em>SendEvent</em> 是同义词; 但通过 <a href="SendMode.htm">SendMode</a> 可以让它变成 <a href="#SendInputDetail">SendInput</a> 或 <a href="#SendPlayDetail">SendPlay</a>的同义词.</p>
 <p id="keynames"><strong>Key Names</strong>: 下表中列出了可以发送的特殊按键(每个按键名称必须用大括号包围):</p>
 <table class="info">
   <tr>


### PR DESCRIPTION
“功能相同”的描述不够正确，使用同义词说明两者完全相同，也与英文版synonymous符合。