### PR TITLE
修正正则一章的错误

### DIFF
--- a/zh-cn/docs/misc/RegEx-QuickRef.htm
+++ b/zh-cn/docs/misc/RegEx-QuickRef.htm
@@ -132,7 +132,7 @@ table.info td:first-child {text-align: center}
   </tr>
 	<tr id="class">
 	  <td><strong>[...]</strong></td>
-	  <td><p><strong>字符类:</strong> 方括号把一列字符或一个范围括在了一起(或两者). 例如, <span class="regex">[abc]</span> 表示 "a, b 或 c 的中任何一个字符". 使用破折号来创建范围; 例如, <span class="regex">[a-z]</span> 表示 "在小写字母 a 和 z(包含的) 之间的任何一个字符". 列表和范围可以组合在一起; 例如 <span class="regex">[a-zA-Z0-9_]</span> 表示 "字母, 数字或下划线中的任何一个字符".</p>
+	  <td><p><strong>字符类:</strong> 方括号把一列字符或一个范围括在了一起(或两者). 例如, <span class="regex">[abc]</span> 表示 "a, b 或 c 的中任何一个字符". 使用破折号来创建范围; 例如, <span class="regex">[a-z]</span> 表示 "在小写字母 a 和 z(包含的) 之间的任何一个字符". 同理, <span class="regex">[一-龟]</span> 表示 "在中文 一 和 龟(包含的) 之间的任何一个字符(即除 龠龡龢龣龤龥 6个生僻字外的全部基本汉字)". 列表和范围可以组合在一起; 例如, <span class="regex">[a-zA-Z0-9_]</span> 表示 "字母, 数字或下划线中的任何一个字符".</p>
 	    <p>字符类后面可以使用 <strong>*</strong>, <strong>?</strong>, <strong>+</strong> 或 <strong>{min,max}</strong> 进行限定. 例如, <span class="regex">[0-9]+</span> 匹配一个或多个任意数字; 因此它可以匹配 xyz<span class="subj">123</span> 但不会匹配 abcxyz.</p>            
         <p>通过 <strong>[[:xxx:]]</strong> 还支持下列 POSIX 命名集, 其中 xxx 是下列单词的其中一个: alnum, alpha, ascii(0-127), blank(space 或 tab), cntrl(控制字符), digit(0-9), xdigit(十六进制数), print, graph(排除了空格的打印字符), punct, lower, upper, space(空白), word(等同于 <a href="#word">\w</a>).</p>
         <p>在字符类中, 只有在类中具有特殊含义的字符才需要进行转义; 例如 <span class="regex">[\^a]</span>, <span class="regex">[a\-b]</span>, <span class="regex">[a\]]</span> 和 <span class="regex">[\\a]</span>.</p></td>

--- a/zh-cn/docs/misc/RegEx-QuickRef.htm
+++ b/zh-cn/docs/misc/RegEx-QuickRef.htm
@@ -188,8 +188,8 @@ table.info td:first-child {text-align: center}
       <p><span class="ver">[v1.0.46.06+]</span>: <strong>\R</strong> 表示 "单个任意类型的换行符", 即在 <a href="#NEWLINE_ANY">`a 选项</a>中列出的这些(然而, \R 在<a href="#class">字符类</a>中仅仅表示字母 "R"). <span class="ver">[v1.0.47.05+]</span>: \R 可以被限制为 CR, LF 和 CRLF 三种, 只需要在模式的开始处(选项后面) 指定大写的(*BSR_ANYCRLF); 例如 <span class="regex">im)(*BSR_ANYCRLF)abc\Rxyz</span></p></td>
   </tr>
   <tr id="slashP">
-    <td><strong>\p{xx}<br>\P{xx}<br>\X</strong></td>
-    <td><p><span class="ver">[AHK_L 61+]:</span> Unicode 字符属性. 在 ANSI 版本中不支持. <strong>\p{xx}</strong> 匹配带 xx 属性的字符而 <strong>\P{xx}</strong> 匹配 <i>不带</i> xx 属性的任意一个字符. 例如, <span class="regex">\pL</span> 匹配任意一个字母而 <span class="regex">\p{Lu}</span> 匹配任意一个大写字母. <strong>\X</strong> 匹配组成扩展 Unicode 序列的任何数目的字符.</p>
+    <td><strong>\p{xx}<br>\P{xx}<br>\x{xx}</strong></td>
+    <td><p><span class="ver">[AHK_L 61+]:</span> Unicode 字符属性. 在 ANSI 版本中不支持. <strong>\p{xx}</strong> 匹配带 xx 属性的字符而 <strong>\P{xx}</strong> 匹配 <i>不带</i> xx 属性的任意一个字符. 例如, <span class="regex">\pL</span> 匹配任意一个字母而 <span class="regex">\p{Lu}</span> 匹配任意一个大写字母. <strong>\x</strong> 匹配组成扩展 Unicode 序列的任何数目的字符. 例如, <span class="regex">[\x{4e00}-\x{9fa5}]</span> 匹配中文.</p>
     <p>对于受支持的属性名称的完整列表和其他细节, 请在 <a href="http://www.pcre.org/pcre.txt">www.pcre.org/pcre.txt</a> 中搜索 "\p{xx}".</p></td>
   </tr>
   <tr id="UCP">


### PR DESCRIPTION
帮助中写的使用大写X匹配unicode字符，这是错误的。经过我的实测，给出了正确的匹配方式，并添加了一个常用的，匹配中文的例子。