### PR TITLE
改正CaretGetPos.htm的syntax节点上的错误

### DIFF
--- a/v2/docs/lib/CaretGetPos.htm
+++ b/v2/docs/lib/CaretGetPos.htm
@@ -15,7 +15,7 @@
 
 <p>检索插入符号的当前位置(文本插入点).</p>
 
-<pre class="Syntax"><span class="func">CaretFound := </span>(<span class="optional">&amp;OutputVarX, &amp;OutputVarY</span>)</pre>
+<pre class="Syntax">CaretFound := <span class="func">CaretGetPos</span>(<span class="optional">&amp;OutputVarX, &amp;OutputVarY</span>)</pre>
 <h2 id="Parameters">参数</h2>
 <dl>
   <dt>&amp;OutputVarX, &amp;OutputVarY</dt>


### PR DESCRIPTION
填补span标签处应该有的函数名，而不是赋值语句